### PR TITLE
docs: add tusky typescript sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Walrus is the next generation of data storage. It is secure, efficient, and dece
 - [Operator Tooling](#operator-tooling)
 
 ## SDKs
-- [Tusky](https://github.com/tusky-io/ts-sdk) - Typescript SDK for e2e encrypted, decentralized file system and pinning service built on Walrus, powering [Tusky app](https://app.tusky.io).
+- [Tusky](https://github.com/tusky-io/ts-sdk) - TypeScript SDK for a complete file system on Walrus. It includes end-to-end encryption, file management and access control.
 ## Visualization
 - Brightlystake - Online dashboards show state's of operators and shards
   - [Walrus Operators Dashboard](https://walrus.brightlystake.com) - [Shards Dashboard](https://walrus.brightlystake.com/shard-owners) - [Further Information](details/brightly-stake.md)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Walrus is the next generation of data storage. It is secure, efficient, and dece
 [**Submit your own developer tool here**](CONTRIBUTING.md)
 
 ## Contents
+- [SDKs](#sdks)
 - [Visualization](#visualization)
 - [Cli Tools](#cli-tools)
 - [Walrus Sites](#walrus-sites)
 - [Operator Tooling](#operator-tooling)
 
+## SDKs
+- [Tusky](https://github.com/tusky-io/ts-sdk) - Typescript SDK for e2e encrypted, decentralized file system and pinning service built on Walrus, powering [Tusky app](https://app.tusky.io).
 ## Visualization
 - Brightlystake - Online dashboards show state's of operators and shards
   - [Walrus Operators Dashboard](https://walrus.brightlystake.com) - [Shards Dashboard](https://walrus.brightlystake.com/shard-owners) - [Further Information](details/brightly-stake.md)

--- a/new_tool_submission_template.md
+++ b/new_tool_submission_template.md
@@ -4,6 +4,7 @@ Tooling Name (Please Replace)
 (Description)
 
 ## Tooling Category
+- [ ] SDKs
 - [ ] Visualization
 - [ ] Cli Tools
 - [ ] Walrus Sites


### PR DESCRIPTION
Tusky Typescript SDK
---

- Add SDKs section 
- Add Tusky Typescript SDK

## Tooling Category
- [x] SDKs
- [ ] Visualization
- [ ] Cli Tools
- [ ] Walrus Sites


## Homepage or Repo or Download Link
https://github.com/tusky-io/ts-sdk
https://app.tusky.io/

## Features
- Authentication with: Enoki / API Keys
- End to end encryption
- File system features

## Documentation or Tutorial
https://docs.tusky.io/about/about-tusky

## Latest Version Number of Walrus Tested On
1.14.1
