### PR TITLE
deprecate Walrus Sites GA and recommend walrus-sites-provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Walrus is the next generation of data storage. It is secure, efficient, and dece
 - [walrus-completion](https://github.com/StakinOfficial/walrus-completion) - A bash, zsh and Python completion for Walrus CLI.
 
 ## Walrus Sites
-- Walrus Sites GA - Reusable GitHub Action for deploying Walrus Sites
-  - [GitHub](https://github.com/zktx-io/walrus-sites-ga) - [Marketplace](https://github.com/marketplace/actions/walrus-sites-ga) - [Examples](https://github.com/zktx-io/walrus-sites-ga-example) - [Further Information](details/walrus_sites_ga.md)
+- [Walrus Sites Provenance](https://github.com/zktx-io/walrus-sites-provenance) - A GitHub Action for securely building, signing, verifying, and deploying Walrus static sites with [SLSA](https://slsa.dev)-compliant provenance.
+  - [Marketplace](https://github.com/marketplace/actions/walrus-sites-provenance) – [Docs](https://github.com/zktx-io/walrus-sites-provenance#readme)
+- [Walrus Sites Notary](https://notary.wal.app) - A verification site to audit Walrus deployments by comparing on-chain resources with signed provenance metadata.
+  - [GitHub](https://github.com/zktx-io/walrus-sites-notary)
+- ⚠️ [Walrus Sites GA](https://github.com/zktx-io/walrus-sites-ga) (Deprecated) – Previously used GitHub Action for deploying Walrus Sites. Replaced by `walrus-sites-provenance`.
 
 ## Operator Tooling
 - [Walrus Aggregator cache config](https://gist.github.com/DataKnox/983d834202e235dc25e9f5ae69e6c2fb) - Steps to configure the Walrus Aggregator Cache with NGinx and LetsEncrypt.

--- a/details/walrus_sites_ga.md
+++ b/details/walrus_sites_ga.md
@@ -1,20 +1,22 @@
-Walrus Sites GitHub Action
+### Walrus Sites GitHub Action (Deprecated)
 ---
-Deploying a Walrus website using GitHub Actions offers an automated workflow that simplifies the deployment process with each code change. This eliminates the need for manual configuration of the Walrus CLI, saving time and reducing errors. GitHub Actions also provide robust version control and history tracking, ensuring a transparent and reliable deployment process with a clear audit trail for every change. With this action, you can seamlessly publish a new website or update an existing one.
 
+> ⚠️ **Deprecated**: This tool is now superseded by [`walrus-sites-provenance`](https://github.com/zktx-io/walrus-sites-provenance), which includes integrated SLSA provenance generation and verification compatibility via [notary.wal.app](https://notary.wal.app).
+
+The original GitHub Action for deploying a Walrus website via GitHub Actions. It provided a basic automated deployment pipeline, eliminating manual configuration of the Walrus CLI and streamlining version control.
 
 ## Tooling Category
-- [ ] Visualization
-- [ ] Cli Tools
-- [X] Walrus Sites
+- [ ] Visualization  
+- [ ] Cli Tools  
+- [x] Walrus Sites
 
 ## Features
-- Publish the site
-- Update the site
+- Publish the site  
+- Update the site  
 
 ## Documentation or Tutorial
-- [Docs](https://docs.zktx.io/walrus/walrus-ga.html)
-
+- [Deprecated Docs](https://docs.zktx.io/walrus/walrus-ga.html)  
+- [Recommended: walrus-sites-provenance](https://github.com/zktx-io/walrus-sites-provenance)
 
 ## Latest Version Number of Sui Tested On
-Testnet v1.32.0
+Testnet

--- a/details/walrus_sites_notary.md
+++ b/details/walrus_sites_notary.md
@@ -1,0 +1,28 @@
+### [Walrus Sites Notary](https://notary.wal.app)
+---
+
+A browser-based verification tool for Walrus Sites. It fetches the on-chain site object and compares its resources against a Sigstore-signed `.intoto.jsonl` file to verify integrity, authenticity, and GitHub-based provenance. Designed to enhance trust in decentralized deployments.
+
+## Tooling Category
+- [ ] SDKs  
+- [x] Visualization  
+- [ ] Cli Tools  
+- [x] Walrus Sites
+
+## Homepage or Repo or Download Link  
+- [Live Website](https://notary.wal.app)  
+- [GitHub Repository](https://github.com/zktx-io/walrus-sites-notary)
+
+## Features
+- Verifies `.intoto.jsonl` provenance attached to Walrus Sites
+- Cross-checks deployed files with their signed hashes
+- Links to GitHub commit, workflow file, and Sigstore transparency log
+- Displays full folder structure and blob IDs
+- Detects verification mismatches and highlights errors
+
+## Documentation or Tutorial
+- [Website](https://notary.wal.app)  
+- [Readme](https://github.com/zktx-io/walrus-sites-notary#readme)
+
+## Latest Version Number of Walrus Tested On
+mainnet

--- a/details/walrus_sites_provenance.md
+++ b/details/walrus_sites_provenance.md
@@ -1,0 +1,31 @@
+### [Walrus Sites Provenance](https://github.com/zktx-io/walrus-sites-provenance)
+---
+
+A GitHub Actions-based workflow that enables verifiable static site deployments to [Walrus Sites](https://wal.app). It automatically builds the site, generates a `.intoto.jsonl` provenance file, signs it using [Sigstore](https://sigstore.dev), and uploads both the site and provenance data, ensuring tamper-resistant and traceable deployments.
+
+## Tooling Category
+- [ ] SDKs  
+- [ ] Visualization  
+- [ ] Cli Tools  
+- [x] Walrus Sites
+
+## Homepage or Repo or Download Link  
+- [GitHub Repository](https://github.com/zktx-io/walrus-sites-provenance)  
+- [GitHub Marketplace](https://github.com/marketplace/actions/walrus-sites-provenance)
+- [Docs](https://docs.zktx.io/slsa/walrus-sites-provenance.html)
+
+## Features
+- Generates signed `.intoto.jsonl` provenance file
+- Supports GitHub OIDC or GitSigner-based PIN approval
+- Fulfills SLSA Level 3 provenance guarantees
+- Seamless integration with Walrus Sites deployments
+- Automatically embeds provenance in `.well-known/`
+- Compatible with verification via [notary.wal.app](https://notary.wal.app)
+
+## Documentation or Tutorial
+- [Getting Started Guide](https://github.com/zktx-io/walrus-sites-provenance#readme)  
+- [Example Deployment Repo](https://github.com/zktx-io/walrus-sites-provenance-example)
+- [Docs](https://docs.zktx.io/slsa/notary.html)
+
+## Latest Version Number of Walrus Tested On
+mainnet


### PR DESCRIPTION
The "Walrus Sites GA" GitHub Action is now deprecated in favor of 
the more robust and secure "walrus-sites-provenance" and "walrus-sites-notary" tools.

These new tools provide:
- End-to-end provenance via Sigstore and SLSA3
- Public verification through notary.wal.app
- Enhanced deployment security without requiring private keys in CI