### PR TITLE
ignore intoto word during typo check

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+intoto = "intoto"


### PR DESCRIPTION
ignore intoto word during typo check