### PR TITLE
Add Walrus DappKit to SDKs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Walrus is the next generation of data storage. It is secure, efficient, and dece
 - [iWalrusSDK](https://github.com/akhtarshahnawaz/iWalrusSDK) - An iOS SDK built to enable smooth uploading, downloading, publisher authentication, caching of binary blobs, and streaming via customizable publisher and aggregator services through the Walrus HTTP API.
 - [Rust SDK](https://github.com/pwh-pwh/walrus_rs) - A Rust client for interacting with the Walrus HTTP API.
 - [Flutter SDK](https://github.com/keem-hyun/walrus_dart) - A Dart client for Walrus with seamless integration.
+- [Walrus DappKit](https://github.com/Danny-Devs/walrus-dapp-kit) - Framework-agnostic reactive hooks for Walrus with React and Vue bindings. Features progress tracking, built-in caching, and typed error handling.
 
 ## Visualization
 


### PR DESCRIPTION
## Summary

- Adds [Walrus DappKit](https://github.com/Danny-Devs/walrus-dapp-kit) to the SDKs section

## About Walrus DappKit

Framework-agnostic reactive hooks for Walrus decentralized blob storage on Sui. Built on [nanostores](https://github.com/nanostores/nanostores) (similar architectural direction as `@mysten/dapp-kit-core`).

**Packages:**
- `@walrus-dapp-kit/core` - Framework-agnostic core with reactive stores
- `@walrus-dapp-kit/react` - React hooks
- `@walrus-dapp-kit/vue` - Vue 3 composables

**Key features:**
- Progress tracking during multi-node uploads
- Built-in blob caching
- Typed error handling patterns
- Reactive state management

## Checklist

- [x] Documentation is complete at primary location
- [x] Uses similar format to existing SDKs
- [x] Repository is public and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)